### PR TITLE
Fix unrepresentable int error.

### DIFF
--- a/src/CBOR.ml
+++ b/src/CBOR.ml
@@ -25,6 +25,10 @@ let put_n b n f x =
   f s 0 x;
   Buffer.add_string b (Bytes.unsafe_to_string s)
 
+let max_uint32 = match Int32.unsigned_to_int 0xffffffffl with
+  | None -> Int.max_int
+  | Some n -> n
+
 let put b ~maj n =
   assert (n >= 0);
   if n < 24 then
@@ -33,7 +37,7 @@ let put b ~maj n =
     begin init b ~maj 24; Buffer.add_char b @@ char_of_int n end
   else if n < 65536 then
     begin init b ~maj 25; put_n b 2 BE.set_int16 n end
-  else if n < 4294967296 then (* optcomp int32 *)
+  else if n <= max_uint32 then
     begin init b ~maj 26; put_n b 4 BE.set_int32 @@ Int32.of_int n end
   else
     begin init b ~maj 27; put_n b 8 BE.set_int64 @@ Int64.of_int n end


### PR DESCRIPTION
Compiling on a 32-bit platform I saw this error:

```
File "src/CBOR.ml", line 36, characters 14-24:
36 |   else if n < 4294967296 then (* optcomp int32 *)
                   ^^^^^^^^^^
Error: Integer literal exceeds the range of representable integers of type int
```

I believe this patch should fix it by instead using the largest
representable int on 32-bit platforms.