### PR TITLE
Add dependency appendix_a.json to tests

### DIFF
--- a/test/dune
+++ b/test/dune
@@ -1,9 +1,8 @@
-
 (executable
   (name test)
   (libraries cbor yojson))
 
 (alias
   (name runtest)
-  (deps test.exe)
+  (deps test.exe appendix_a.json)
   (action (run ./test.exe appendix_a.json)))


### PR DESCRIPTION
Otherwise `dune runtest` fails with an exception `Fatal error: exception Sys_error("appendix_a.json: No such file or directory")`.